### PR TITLE
Rename email function to cakemail_send_email

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -211,8 +211,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 
       // Email API (updated naming and description)
       {
-        name: 'cakemail_send_transactional_email',
-        description: 'Send an email using Cakemail v2 Email API (supports both transactional and marketing emails)',
+        name: 'cakemail_send_email',
+        description: 'Send an email using Cakemail Email API (supports both transactional and marketing emails)',
         inputSchema: {
           type: 'object',
           properties: {
@@ -367,7 +367,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       // Email API (updated to use new EmailApi)
-      case 'cakemail_send_transactional_email': {
+      case 'cakemail_send_email': {
         const { 
           to_email, 
           to_name, 
@@ -410,7 +410,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           content: [
             {
               type: 'text',
-              text: `📧 **Email sent successfully via v2 API!**\\n\\n` +
+              text: `📧 **Email sent successfully via Email API!**\\n\\n` +
                     `✅ **Email ID:** ${email.data?.id}\\n` +
                     `✅ **Status:** ${email.data?.status}\\n` +
                     `✅ **Type:** ${email_type || 'transactional'}\\n` +


### PR DESCRIPTION
This PR renames the internal function name from `cakemail_send_transactional_email` to `cakemail_send_email` to better reflect its purpose as a general Email API function.

## Changes Made

- **Function name**: `cakemail_send_transactional_email` → `cakemail_send_email`
- **Description**: Updated to refer to "Email API" instead of "v2 Email API"
- **Success messages**: Updated to use consistent "Email API" terminology
- **All functionality preserved**: Same parameters, same behavior, same capabilities

## Why This Change?

The previous name `cakemail_send_transactional_email` was misleading because:
1. The function supports both transactional AND marketing emails
2. "Email API" is a cleaner, more generic name
3. It better represents the function's true purpose

## Backward Compatibility

This change only affects the internal function name exposed to Claude. All existing functionality, parameters, and behavior remain exactly the same.

## Testing

- ✅ Function name updated in tool registration
- ✅ Function name updated in switch case handler
- ✅ All parameters and validation unchanged
- ✅ Success messages updated with new terminology